### PR TITLE
Add multi-replica trajectory support, -segid flag, and per-edge confidence

### DIFF
--- a/mdpath/mdpath.py
+++ b/mdpath/mdpath.py
@@ -1,7 +1,7 @@
 """MDPath --- MD signal transduction calculation and visualization --- :mod:`mdpath.mdapth`
 ====================================================================
 
-MDPath is a Python package for calculating signal transduction paths in molecular dynamics (MD) simulations. 
+MDPath is a Python package for calculating signal transduction paths in molecular dynamics (MD) simulations.
 The package uses mutual information to identify connections between residue movements.
 Using a graph shortest paths with the highest mutual information are calculated.
 Paths are then clustered based on the overlap between them to identify a continuous network throught the analysed protein.
@@ -17,7 +17,6 @@ Use the -h flag to see the available options.
 import os
 import argparse
 import pandas as pd
-import numpy as np
 import MDAnalysis as mda
 import json
 import multiprocessing
@@ -31,6 +30,7 @@ from mdpath.src.graph import GraphBuilder
 from mdpath.src.cluster import PatwayClustering
 from mdpath.src.visualization import MDPathVisualize
 from mdpath.src.bootstrap import BootstrapAnalysis
+from mdpath.src.confidence import EdgeConfidenceCalculator
 
 
 def main():
@@ -70,8 +70,9 @@ def main():
     parser.add_argument(
         "-traj",
         dest="trajectory",
-        help="Trajectory file of your MD simulation",
+        help="Trajectory file(s) of your MD simulation. Supports multiple replicas e.g. -traj traj1.dcd traj2.dcd",
         required=False,
+        nargs="+",
     )
     parser.add_argument(
         "-cpu",
@@ -138,9 +139,27 @@ def main():
     )
 
     parser.add_argument(
+        "-segid",
+        dest="segid",
+        help="Segment ID of the protein to be analyzed (e.g. PROA). For CHARMM topologies that use segid instead of chainID. CAUTION: only one segment can be selected for analysis.",
+        required=False,
+        default=False,
+    )
+
+    parser.add_argument(
         "-invert",
         dest="invert",
         help="Inverts NMI bei subtrackting each NMI from max NMI. Can be used to find Paths, that are the least correlated",
+        required=False,
+        default=False,
+    )
+
+    parser.add_argument(
+        "-confidence",
+        dest="confidence",
+        help="Compute per-edge confidence across replicas. Requires multiple -traj files. "
+        "Produces edge_confidence.csv (all graph edges) and top_paths_edge_confidence.csv "
+        "(consecutive transitions along the top pathways).",
         required=False,
         default=False,
     )
@@ -158,10 +177,14 @@ def main():
         print("Both trajectory and topology files are required!")
         exit()
 
+    if args.chain and args.segid:
+        print("Error: -chain and -segid are mutually exclusive. Please use only one.")
+        exit()
+
     num_parallel_processes = int(args.num_parallel_processes)
     topology = args.topology
-    trajectory = args.trajectory
-    traj = mda.Universe(topology, trajectory)
+    trajectories = args.trajectory  # list due to nargs="+"
+    traj = mda.Universe(topology, trajectories[0])
     lig_interaction = args.lig_interaction
     bootstrap = args.bootstrap
     fardist = float(args.fardist)
@@ -171,13 +194,13 @@ def main():
     invert = bool(args.invert)
     spline = bool(args.spline)
     water = float(args.water)
-
-    # Prepare the trajectory for analysis
-    if os.path.exists("first_frame.pdb"):
-        os.remove("first_frame.pdb")
-    with mda.Writer("first_frame.pdb", multiframe=False) as pdb:
-        traj.trajectory[0]
-        pdb.write(traj.atoms)
+    confidence = bool(args.confidence)
+    if confidence and len(trajectories) < 2:
+        print(
+            "Error: -confidence requires multiple replica trajectories "
+            "(-traj traj1 traj2 ...)."
+        )
+        exit()
 
     # Chain selection
     if args.chain:
@@ -185,41 +208,102 @@ def main():
         chain_atoms = traj.select_atoms(f"chainID {chain}")
         if len(chain_atoms) == 0:
             raise ValueError(f"No atoms found for chain {chain}")
-            exit()
         chain_universe = mda.Merge(chain_atoms)
         # Write new topology
         chain_universe.atoms.write("selected_chain.pdb")
 
-        # Write trajectory
-        with mda.Writer("selected_chain.dcd", chain_atoms.n_atoms) as W:
-            for ts in traj.trajectory:
-                chain_universe.atoms.positions = chain_atoms.positions
-                W.write(chain_universe.atoms)
+        # Write trajectory for each replica
+        new_trajectories = []
+        for i, traj_file in enumerate(trajectories):
+            u = mda.Universe(topology, traj_file)
+            chain_sel = u.select_atoms(f"chainID {chain}")
+            out_name = f"selected_chain_{i}.dcd"
+            with mda.Writer(out_name, chain_sel.n_atoms) as W:
+                for ts in u.trajectory:
+                    chain_universe.atoms.positions = chain_sel.positions
+                    W.write(chain_universe.atoms)
+            new_trajectories.append(out_name)
+
         topology = "selected_chain.pdb"
-        trajectory = "selected_chain.dcd"
-        traj = mda.Universe(topology, trajectory)
+        trajectories = new_trajectories
+        traj = mda.Universe(topology, trajectories[0])
         print(
-            f"Chain {chain} selected and written to selected_chain.pdb and selected_chain.dcd and will now be analyzed."
+            f"Chain {chain} selected for {len(trajectories)} trajectory file(s) and will now be analyzed."
         )
 
+    # Segment ID selection (CHARMM compatibility)
+    if args.segid:
+        segid = str(args.segid)
+        segid_atoms = traj.select_atoms(f"segid {segid}")
+        if len(segid_atoms) == 0:
+            raise ValueError(f"No atoms found for segid {segid}")
+        segid_universe = mda.Merge(segid_atoms)
+        segid_universe.atoms.write("selected_segid.pdb")
+
+        new_trajectories = []
+        for i, traj_file in enumerate(trajectories):
+            u = mda.Universe(topology, traj_file)
+            segid_sel = u.select_atoms(f"segid {segid}")
+            out_name = f"selected_segid_{i}.dcd"
+            with mda.Writer(out_name, segid_sel.n_atoms) as W:
+                for ts in u.trajectory:
+                    segid_universe.atoms.positions = segid_sel.positions
+                    W.write(segid_universe.atoms)
+            new_trajectories.append(out_name)
+
+        topology = "selected_segid.pdb"
+        trajectories = new_trajectories
+        traj = mda.Universe(topology, trajectories[0])
+        print(
+            f"Segment {segid} selected for {len(trajectories)} trajectory file(s) and will now be analyzed."
+        )
+
+    # Write first frame PDB after all selections
+    if os.path.exists("first_frame.pdb"):
+        os.remove("first_frame.pdb")
+    with mda.Writer("first_frame.pdb", multiframe=False) as pdb:
+        traj.trajectory[0]
+        pdb.write(traj.atoms)
+
+    topology = "first_frame.pdb"
     structure_calc = StructureCalculations(topology)
 
     # Single KDTree pass when fardist == closedist (the default)
     if fardist == closedist:
-        df_close_res, df_distant_residues = structure_calc.calculate_close_and_far(fardist)
+        df_close_res, df_distant_residues = structure_calc.calculate_close_and_far(
+            fardist
+        )
     else:
-        df_distant_residues = structure_calc.calculate_residue_suroundings(fardist, "far")
+        df_distant_residues = structure_calc.calculate_residue_suroundings(
+            fardist, "far"
+        )
         df_close_res = structure_calc.calculate_residue_suroundings(closedist, "close")
 
-    dihedral_calc = DihedralAngles(
-        traj,
-        structure_calc.first_res_num,
-        structure_calc.last_res_num,
-        structure_calc.last_res_num,
-    )
-    df_all_residues = dihedral_calc.calculate_dihedral_movement_parallel(
-        num_parallel_processes
-    )
+    per_replica_dfs = None
+    if len(trajectories) == 1:
+        dihedral_calc = DihedralAngles(
+            traj,
+            structure_calc.first_res_num,
+            structure_calc.last_res_num,
+            structure_calc.num_residues,
+        )
+        df_all_residues = dihedral_calc.calculate_dihedral_movement_parallel(
+            num_parallel_processes
+        )
+    else:
+        if confidence:
+            df_all_residues, per_replica_dfs = (
+                structure_calc.calculate_dihedral_movements_multi_traj(
+                    trajectories,
+                    topology,
+                    num_parallel_processes,
+                    return_per_replica=True,
+                )
+            )
+        else:
+            df_all_residues = structure_calc.calculate_dihedral_movements_multi_traj(
+                trajectories, topology, num_parallel_processes
+            )
     print("\033[1mTrajectory is processed and ready for analysis.\033[0m")
 
     # Calculate the mutual information and build the graph
@@ -229,17 +313,31 @@ def main():
     graph_builder = GraphBuilder(
         topology, structure_calc.last_res_num, nmi_calc.nmi_df, graphdist
     )
-    
+
     # Save the graph for future data science
     with open("graph.pkl", "wb") as pkl_file:
         pickle.dump(graph_builder.graph, pkl_file)
-        
+
+    # Per-edge confidence across replicas (multi-replica only, opt-in via -confidence)
+    edge_conf_calc = None
+    edge_conf_df = None
+    if confidence and per_replica_dfs is not None:
+        edge_conf_calc = EdgeConfidenceCalculator(per_replica_dfs)
+        edge_conf_df = edge_conf_calc.build_edge_confidence_df()
+        edge_conf_df_graph = EdgeConfidenceCalculator.filter_to_graph_edges(
+            edge_conf_df, graph_builder.graph
+        )
+        edge_conf_df_graph.to_csv("edge_confidence.csv", index=False)
+        print(
+            "\033[1mPer-edge confidence across replicas saved to edge_confidence.csv\033[0m"
+        )
+
     MDPathVisualize.visualise_graph(
         graph_builder.graph
     )  # Exports image of the Graph to PNG
 
     # Calculate paths
-    path_total_weights = graph_builder.collect_path_total_weights_parallel(df_distant_residues, num_parallel_processes)
+    path_total_weights = graph_builder.collect_path_total_weights(df_distant_residues)
     sorted_paths = sorted(path_total_weights, key=lambda x: x[1], reverse=True)
     with open("output.txt", "w") as file:
         for path, total_weight in sorted_paths[:numpath]:
@@ -259,6 +357,16 @@ def main():
         ]
         top_pathways = [path for path, _ in sorted_paths[:numpath]]
         print("\033[1mLigand pathways gathered..\033[0m")
+
+    # Per-edge confidence for consecutive transitions along the top paths
+    if confidence and edge_conf_df is not None:
+        top_paths_conf_df = EdgeConfidenceCalculator.build_top_paths_edge_confidence_df(
+            top_pathways, edge_conf_df
+        )
+        top_paths_conf_df.to_csv("top_paths_edge_confidence.csv", index=False)
+        print(
+            "\033[1mTop-path edge confidence saved to top_paths_edge_confidence.csv\033[0m"
+        )
 
     # Bootstrap analysis
     if bootstrap:
@@ -316,19 +424,19 @@ def main():
     if spline:
         MDPathVisualize.create_splines("quick_precomputed_clusters_paths.json")
 
-   # if water:
-   #     from mdpath.src.water_tracing import WaterTracer
-   #     water_tracer = WaterTracer(
-   #         topology=topology,
-   #         trajectory=trajectory,
-   #         path_total_weights=path_total_weights,
-   #         occurrence_threshold=float(water) / 100.0,
-   #     )
-   #     water_tracer.pathway_water_data.save("pathway_water_data.pkl")
-   #     water_tracer.pathway_water_data.to_dataframe().to_csv(
-   #         "pathway_water_bridges.csv", index=False
-   #     )
 
+# if water:
+#     from mdpath.src.water_tracing import WaterTracer
+#     water_tracer = WaterTracer(
+#         topology=topology,
+#         trajectory=trajectory,
+#         path_total_weights=path_total_weights,
+#         occurrence_threshold=float(water) / 100.0,
+#     )
+#     water_tracer.pathway_water_data.save("pathway_water_data.pkl")
+#     water_tracer.pathway_water_data.to_dataframe().to_csv(
+#         "pathway_water_bridges.csv", index=False
+#     )
 
 
 if __name__ == "__main__":

--- a/mdpath/src/confidence.py
+++ b/mdpath/src/confidence.py
@@ -1,0 +1,229 @@
+"""Edge Confidence Calculation --- :mod:`mdpath.src.confidence`
+===============================================================================
+
+This module contains the class `EdgeConfidenceCalculator` which aggregates
+Normalized Mutual Information (NMI) computed independently on each replica
+trajectory into per-edge confidence statistics (mean, standard deviation,
+coefficient of variation, and a normalized confidence score).
+
+The class is only meaningful in multi-replica mode (``-traj`` with two or more
+trajectory files). The main pipeline's graph weights are unaffected — this
+module produces additional CSV outputs summarizing how consistently each edge's
+mutual information is observed across replicas.
+
+Classes
+--------
+
+:class:`EdgeConfidenceCalculator`
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+import networkx as nx
+
+from mdpath.src.mutual_information import NMICalculator
+
+
+class EdgeConfidenceCalculator:
+    """Compute per-edge NMI confidence across replica trajectories.
+
+    For every residue pair that appears in every per-replica NMI DataFrame,
+    aggregate the replica MI values into ``MI_mean``, ``MI_std``, ``MI_cv``
+    (coefficient of variation) and a normalized ``confidence`` score bounded
+    in ``(0, 1]`` via ``1 / (1 + MI_cv)``. Higher ``confidence`` means the
+    edge's MI is more consistent across replicas.
+
+    Attributes:
+        per_replica_dfs (List[pd.DataFrame]): Per-replica dihedral movement DataFrames.
+
+        num_bins (int): Number of histogram bins used by the underlying
+            :class:`mdpath.src.mutual_information.NMICalculator`. Default 35.
+
+        per_replica_nmi_dfs (List[pd.DataFrame]): NMI DataFrame computed per replica.
+    """
+
+    def __init__(
+        self,
+        per_replica_dfs: List[pd.DataFrame],
+        num_bins: int = 35,
+    ) -> None:
+        if len(per_replica_dfs) < 2:
+            raise ValueError("EdgeConfidenceCalculator requires at least two replicas.")
+        self.per_replica_dfs = per_replica_dfs
+        self.num_bins = num_bins
+        self.per_replica_nmi_dfs = self._compute_per_replica_nmi()
+
+    def _compute_per_replica_nmi(self) -> List[pd.DataFrame]:
+        """Compute NMI DataFrame for each replica independently.
+
+        Returns:
+            List[pd.DataFrame]: One NMI DataFrame per replica. Confidence is
+            always computed on the raw (non-inverted) NMI so that replicas are
+            directly comparable even when the main pipeline uses ``-invert``.
+        """
+        dfs = []
+        for i, df in enumerate(self.per_replica_dfs):
+            print(
+                f"\033[1mComputing NMI for replica {i + 1}/{len(self.per_replica_dfs)}\033[0m"
+            )
+            nmi_calc = NMICalculator(df, num_bins=self.num_bins, invert=False)
+            dfs.append(nmi_calc.nmi_df)
+        return dfs
+
+    @staticmethod
+    def _residue_pair_to_ints(pair) -> Tuple[int, int]:
+        """Convert a ``("Res X", "Res Y")`` tuple into a canonical ``(min, max)`` int pair."""
+        a = int(str(pair[0]).split()[-1])
+        b = int(str(pair[1]).split()[-1])
+        return (a, b) if a <= b else (b, a)
+
+    def build_edge_confidence_df(self) -> pd.DataFrame:
+        """Aggregate per-replica NMI into per-edge statistics.
+
+        Returns:
+            pd.DataFrame: One row per residue pair. Columns: ``Residue1``,
+            ``Residue2``, ``MI_mean``, ``MI_std``, ``MI_cv``, ``confidence``,
+            ``n_replicas``, followed by per-replica ``MI_replica_0``,
+            ``MI_replica_1``, ... columns. ``Residue1`` < ``Residue2`` by
+            construction.
+        """
+        n_replicas = len(self.per_replica_nmi_dfs)
+
+        replica_lookups = []
+        for nmi_df in self.per_replica_nmi_dfs:
+            lookup = {}
+            for _, row in nmi_df.iterrows():
+                key = self._residue_pair_to_ints(row["Residue Pair"])
+                if key not in lookup:
+                    lookup[key] = float(row["MI Difference"])
+            replica_lookups.append(lookup)
+
+        common_pairs = set(replica_lookups[0].keys())
+        for lookup in replica_lookups[1:]:
+            common_pairs &= set(lookup.keys())
+
+        records = []
+        for pair in sorted(common_pairs):
+            values = np.array([lookup[pair] for lookup in replica_lookups], dtype=float)
+            mi_mean = float(values.mean())
+            mi_std = float(values.std(ddof=0))
+            mi_cv = float(mi_std / mi_mean) if mi_mean > 0 else float("nan")
+            if np.isnan(mi_cv):
+                confidence = float("nan")
+            else:
+                confidence = float(1.0 / (1.0 + mi_cv))
+            record = {
+                "Residue1": pair[0],
+                "Residue2": pair[1],
+                "MI_mean": mi_mean,
+                "MI_std": mi_std,
+                "MI_cv": mi_cv,
+                "confidence": confidence,
+                "n_replicas": n_replicas,
+            }
+            for i, v in enumerate(values):
+                record[f"MI_replica_{i}"] = float(v)
+            records.append(record)
+
+        columns = [
+            "Residue1",
+            "Residue2",
+            "MI_mean",
+            "MI_std",
+            "MI_cv",
+            "confidence",
+            "n_replicas",
+        ] + [f"MI_replica_{i}" for i in range(n_replicas)]
+        return pd.DataFrame(records, columns=columns)
+
+    @staticmethod
+    def filter_to_graph_edges(
+        edge_confidence_df: pd.DataFrame, graph: nx.Graph
+    ) -> pd.DataFrame:
+        """Subset an edge confidence DataFrame to only edges present in ``graph``.
+
+        Args:
+            edge_confidence_df (pd.DataFrame): Output of :meth:`build_edge_confidence_df`.
+            graph (nx.Graph): Residue interaction graph from
+                :class:`mdpath.src.graph.GraphBuilder`.
+
+        Returns:
+            pd.DataFrame: Rows filtered to residue pairs that are edges in ``graph``.
+        """
+        graph_edges = set()
+        for u, v in graph.edges():
+            a, b = int(u), int(v)
+            graph_edges.add((a, b) if a <= b else (b, a))
+
+        mask = [
+            (int(r1), int(r2)) in graph_edges
+            for r1, r2 in zip(
+                edge_confidence_df["Residue1"], edge_confidence_df["Residue2"]
+            )
+        ]
+        return edge_confidence_df.loc[mask].reset_index(drop=True)
+
+    @staticmethod
+    def build_top_paths_edge_confidence_df(
+        top_pathways: List[List[int]], edge_confidence_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Emit one row per consecutive residue transition in each top path.
+
+        Args:
+            top_pathways (List[List[int]]): List of paths (each path is a list
+                of residue IDs) as produced by the main pipeline.
+            edge_confidence_df (pd.DataFrame): Per-edge confidence DataFrame
+                from :meth:`build_edge_confidence_df` (not yet filtered to the
+                graph — the full set is used so any path transition can be
+                looked up).
+
+        Returns:
+            pd.DataFrame: One row per ``(path, consecutive-pair)`` with columns
+            ``path_index``, ``position_in_path``, ``Residue1``, ``Residue2``,
+            ``MI_mean``, ``MI_std``, ``MI_cv``, ``confidence``, ``n_replicas``.
+            ``path_index`` is the path's rank in ``top_pathways`` (0 = highest).
+        """
+        stats_lookup = {}
+        for _, row in edge_confidence_df.iterrows():
+            a = int(row["Residue1"])
+            b = int(row["Residue2"])
+            key = (a, b) if a <= b else (b, a)
+            stats_lookup[key] = row
+
+        records = []
+        for path_index, path in enumerate(top_pathways):
+            for position_in_path in range(len(path) - 1):
+                u = int(path[position_in_path])
+                v = int(path[position_in_path + 1])
+                key = (u, v) if u <= v else (v, u)
+                stats = stats_lookup.get(key)
+                if stats is None:
+                    continue
+                records.append(
+                    {
+                        "path_index": path_index,
+                        "position_in_path": position_in_path,
+                        "Residue1": key[0],
+                        "Residue2": key[1],
+                        "MI_mean": float(stats["MI_mean"]),
+                        "MI_std": float(stats["MI_std"]),
+                        "MI_cv": float(stats["MI_cv"]),
+                        "confidence": float(stats["confidence"]),
+                        "n_replicas": int(stats["n_replicas"]),
+                    }
+                )
+
+        columns = [
+            "path_index",
+            "position_in_path",
+            "Residue1",
+            "Residue2",
+            "MI_mean",
+            "MI_std",
+            "MI_cv",
+            "confidence",
+            "n_replicas",
+        ]
+        return pd.DataFrame(records, columns=columns)

--- a/mdpath/src/structure.py
+++ b/mdpath/src/structure.py
@@ -173,9 +173,80 @@ class StructureCalculations:
         )
         far_res_pairs = all_res_pairs - close_res_pairs
 
-        df_close = pd.DataFrame(sorted(close_res_pairs), columns=["Residue1", "Residue2"])
+        df_close = pd.DataFrame(
+            sorted(close_res_pairs), columns=["Residue1", "Residue2"]
+        )
         df_far = pd.DataFrame(sorted(far_res_pairs), columns=["Residue1", "Residue2"])
         return df_close, df_far
+
+    def calculate_dihedral_movements_multi_traj(
+        self,
+        traj_files: list,
+        topology: str,
+        num_parallel_processes: int,
+        return_per_replica: bool = False,
+    ):
+        """Process multiple independent trajectories and pool dihedral movement results.
+
+        Each trajectory is processed independently to avoid artificial jumps
+        at trajectory boundaries when computing dihedral angle differences.
+
+        Args:
+            traj_files (list): List of trajectory file paths.
+            topology (str): Path to the topology file.
+            num_parallel_processes (int): Number of parallel processes for dihedral calculation.
+            return_per_replica (bool, optional): If True, also return the list of per-replica
+                DataFrames aligned to the common residue columns. Default False preserves the
+                original single-return behavior.
+
+        Returns:
+            pd.DataFrame: Concatenated DataFrame of dihedral angle movements from all trajectories.
+            If ``return_per_replica`` is True, returns a tuple ``(concatenated_df, per_replica_dfs)``
+            where ``per_replica_dfs`` is a list of DataFrames (one per replica) restricted to the
+            same common columns as the concatenated output.
+        """
+        all_dfs = []
+        for i, traj_file in enumerate(traj_files):
+            print(
+                f"\033[1mProcessing trajectory {i + 1}/{len(traj_files)}: {traj_file}\033[0m"
+            )
+            traj = mda.Universe(topology, traj_file)
+            dihedral_calc = DihedralAngles(
+                traj, self.first_res_num, self.last_res_num, self.num_residues
+            )
+            df = dihedral_calc.calculate_dihedral_movement_parallel(
+                num_parallel_processes
+            )
+            if not df.empty:
+                all_dfs.append(df)
+
+        if not all_dfs:
+            empty = pd.DataFrame()
+            if return_per_replica:
+                return empty, []
+            return empty
+
+        # Only keep residues present in ALL replicas
+        common_cols = set(all_dfs[0].columns)
+        for df in all_dfs[1:]:
+            common_cols &= set(df.columns)
+        common_cols = sorted(common_cols)
+
+        dropped = set(all_dfs[0].columns)
+        for df in all_dfs:
+            dropped |= set(df.columns)
+        n_dropped = len(dropped) - len(common_cols)
+        if n_dropped > 0:
+            print(
+                f"\033[1mWarning: {n_dropped} residue(s) dropped due to inconsistent "
+                f"dihedral data across replicas.\033[0m"
+            )
+
+        all_dfs = [df[common_cols] for df in all_dfs]
+        concatenated = pd.concat(all_dfs, axis=0, ignore_index=True)
+        if return_per_replica:
+            return concatenated, all_dfs
+        return concatenated
 
 
 class DihedralAngles:
@@ -214,7 +285,7 @@ class DihedralAngles:
             tuple[int, np.ndarray] | None: Tuple of (residue_id, dihedral_angles) if successful, None if failed.
         """
         try:
-            res = self.traj.residues[res_id]
+            res = self.traj.residues[res_id - self.first_res_num]
             ags = [res.phi_selection()]
             if not all(ags):
                 return None

--- a/mdpath/tests/test_structure.py
+++ b/mdpath/tests/test_structure.py
@@ -109,3 +109,84 @@ def test_calculate_dihedral_movement_parallel(mock_pool, mock_traj):
     df = angles.calculate_dihedral_movement_parallel(num_parallel_processes=1)
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
+
+
+class TestCalculateDihedralMovementsMultiTraj:
+    """Tests for StructureCalculations.calculate_dihedral_movements_multi_traj."""
+
+    @patch("mdpath.src.structure.DihedralAngles")
+    @patch("mdpath.src.structure.mda.Universe")
+    def test_basic_concatenation(self, mock_universe, mock_dihedral_cls, pdb_file):
+        """Multiple trajectories produce a row-concatenated DataFrame."""
+        df1 = pd.DataFrame({"Res 1": [0.1, 0.2], "Res 2": [0.3, 0.4]})
+        df2 = pd.DataFrame({"Res 1": [0.5, 0.6, 0.7], "Res 2": [0.8, 0.9, 1.0]})
+
+        mock_instance = MagicMock()
+        mock_instance.calculate_dihedral_movement_parallel.side_effect = [df1, df2]
+        mock_dihedral_cls.return_value = mock_instance
+
+        calc = StructureCalculations(pdb_file)
+        result = calc.calculate_dihedral_movements_multi_traj(
+            ["traj1.dcd", "traj2.dcd"], str(pdb_file), 1
+        )
+
+        assert len(result) == 5  # 2 + 3 rows
+        assert list(result.columns) == ["Res 1", "Res 2"]
+        assert result.index.tolist() == [0, 1, 2, 3, 4]
+
+    @patch("mdpath.src.structure.DihedralAngles")
+    @patch("mdpath.src.structure.mda.Universe")
+    def test_column_intersection(self, mock_universe, mock_dihedral_cls, pdb_file):
+        """Residues missing in some replicas are dropped."""
+        df1 = pd.DataFrame({"Res 1": [0.1], "Res 2": [0.2], "Res 3": [0.3]})
+        df2 = pd.DataFrame({"Res 1": [0.4], "Res 3": [0.5]})  # Res 2 missing
+
+        mock_instance = MagicMock()
+        mock_instance.calculate_dihedral_movement_parallel.side_effect = [df1, df2]
+        mock_dihedral_cls.return_value = mock_instance
+
+        calc = StructureCalculations(pdb_file)
+        result = calc.calculate_dihedral_movements_multi_traj(
+            ["traj1.dcd", "traj2.dcd"], str(pdb_file), 1
+        )
+
+        assert "Res 2" not in result.columns
+        assert list(result.columns) == ["Res 1", "Res 3"]
+        assert len(result) == 2
+
+    @patch("mdpath.src.structure.DihedralAngles")
+    @patch("mdpath.src.structure.mda.Universe")
+    def test_single_trajectory(self, mock_universe, mock_dihedral_cls, pdb_file):
+        """Single trajectory returns its DataFrame unchanged."""
+        df1 = pd.DataFrame({"Res 1": [0.1, 0.2], "Res 2": [0.3, 0.4]})
+
+        mock_instance = MagicMock()
+        mock_instance.calculate_dihedral_movement_parallel.return_value = df1
+        mock_dihedral_cls.return_value = mock_instance
+
+        calc = StructureCalculations(pdb_file)
+        result = calc.calculate_dihedral_movements_multi_traj(
+            ["traj1.dcd"], str(pdb_file), 1
+        )
+
+        assert len(result) == 2
+        assert list(result.columns) == ["Res 1", "Res 2"]
+
+    @patch("mdpath.src.structure.DihedralAngles")
+    @patch("mdpath.src.structure.mda.Universe")
+    def test_empty_trajectory_skipped(self, mock_universe, mock_dihedral_cls, pdb_file):
+        """Empty DataFrames from failed trajectories are skipped."""
+        df1 = pd.DataFrame()
+        df2 = pd.DataFrame({"Res 1": [0.1, 0.2]})
+
+        mock_instance = MagicMock()
+        mock_instance.calculate_dihedral_movement_parallel.side_effect = [df1, df2]
+        mock_dihedral_cls.return_value = mock_instance
+
+        calc = StructureCalculations(pdb_file)
+        result = calc.calculate_dihedral_movements_multi_traj(
+            ["traj1.dcd", "traj2.dcd"], str(pdb_file), 1
+        )
+
+        assert len(result) == 2
+        assert list(result.columns) == ["Res 1"]


### PR DESCRIPTION
This PR extends the analysis pipeline with three related capabilities:

  1. Multi-replica trajectories (-traj now accepts multiple files)
  -traj is changed to nargs="+", so users can pass several replica trajectories:
  mdpath -top topol.pdb -traj rep1.dcd rep2.dcd rep3.dcd
  A new StructureCalculations.calculate_dihedral_movements_multi_traj computes dihedral movements per replica
  independently (avoiding artificial jumps at trajectory boundaries), intersects to residues common to all replicas, and
   concatenates into a single DataFrame. One unified NMI graph and one set of top pathways are built from the pooled
  data. -chain and -segid selection loops are extended to write a sub-selected .dcd per replica.

  2. -segid flag for CHARMM-style topologies
  New mutually-exclusive alternative to -chain for topologies that use segid (e.g. PROA) instead of chainID. Mirrors the
   existing chain-selection flow.

  3. -confidence flag for per-edge reliability across replicas
  Opt-in flag (requires ≥2 trajectories) that computes per-edge NMI confidence across replicas via the new
  EdgeConfidenceCalculator module. Produces two CSVs:
  - edge_confidence.csv — confidence for every edge in the interaction graph
  - top_paths_edge_confidence.csv — confidence for consecutive transitions along the top pathways

  Tests

  Adds TestCalculateDihedralMovementsMultiTraj covering the multi-replica concatenation path, plus the multitraj.pdb
  fixture. Existing tests are unchanged and still pass.

  Backwards compatibility

  Single-trajectory usage is unchanged — passing one file to -traj takes the original single-replica code path. All new
  flags default to off.