### PR TITLE
 Add confidence-colored pathway visualization for ChimeraX

### DIFF
--- a/mdpath/mdpath.py
+++ b/mdpath/mdpath.py
@@ -31,6 +31,7 @@ from mdpath.src.cluster import PatwayClustering
 from mdpath.src.visualization import MDPathVisualize
 from mdpath.src.bootstrap import BootstrapAnalysis
 from mdpath.src.confidence import EdgeConfidenceCalculator
+from mdpath.src.path_confidence_viz import ConfidencePathVisualizer
 
 
 def main():
@@ -158,8 +159,9 @@ def main():
         "-confidence",
         dest="confidence",
         help="Compute per-edge confidence across replicas. Requires multiple -traj files. "
-        "Produces edge_confidence.csv (all graph edges) and top_paths_edge_confidence.csv "
-        "(consecutive transitions along the top pathways).",
+        "Produces edge_confidence.csv (all graph edges), top_paths_edge_confidence.csv "
+        "(consecutive transitions along the top pathways), and confidence_paths_chimerax.py "
+        "(a self-contained ChimeraX viewer of the top paths colored by confidence).",
         required=False,
         default=False,
     )
@@ -404,6 +406,26 @@ def main():
 
     with open("top_pathways.pkl", "wb") as pkl_file:
         pickle.dump(top_pathways, pkl_file)
+
+    # Self-contained ChimeraX viewer of the top paths colored by replica
+    # confidence (auto-scaled tube thickness, hover shows the value).
+    if confidence and edge_conf_df is not None:
+        try:
+            conf_vis = ConfidencePathVisualizer.write_chimerax_script(
+                top_pathways,
+                residue_coordinates_dict,
+                edge_conf_df,
+                pdb_file="first_frame.pdb",
+                out_path="confidence_paths_chimerax.py",
+            )
+            print(
+                "\033[1mChimeraX confidence viewer saved to confidence_paths_chimerax.py "
+                "({0} paths, tube radius {1:.2f}-{2:.2f} A). Drag it onto a ChimeraX window.\033[0m".format(
+                    conf_vis["paths"], conf_vis["radius_min"], conf_vis["radius_max"]
+                )
+            )
+        except Exception as exc:
+            print(f"Could not generate ChimeraX confidence viewer: {exc}")
 
     # Export the cluster pathways for visualization
     updated_dict = MDPathVisualize.apply_backtracking(

--- a/mdpath/mdpath_tools.py
+++ b/mdpath/mdpath_tools.py
@@ -463,6 +463,84 @@ def spline():
     json_file = args.json
     MDPathVisualize.create_splines(json_file)
 
+
+def confidence_spline():
+    """Create a self-contained ChimeraX viewer of the top paths colored by
+    multi-replica confidence.
+
+    Builds ``confidence_paths_chimerax.py`` from the standard MDPath confidence
+    outputs. The paths are drawn as spline tubes where colour encodes confidence
+    (blue = high, red = low), thickness encodes how many paths share a connection
+    (auto-scaled to the structure size), and hovering a path shows its confidence.
+    The structure and geometry are embedded, so the output is a single file you
+    drag onto a ChimeraX window. It can be called using 'mdpath_confidence_spline'
+    after installation.
+
+    Command-line inputs:
+        -paths (str): top_pathways.pkl from the MDPath analysis.
+
+        -coords (str): residue_coordinates.pkl from the MDPath analysis.
+
+        -conf (str): edge_confidence.csv from the MDPath analysis (-confidence run).
+
+        -pdb (str): Structure the paths were computed on (default: first_frame.pdb).
+
+        -top (int): Number of top paths to render (default: 25).
+
+        -o (str): Output ChimeraX .py path (default: confidence_paths_chimerax.py).
+
+        -radiusmin / -radiusmax (float): Override the auto-scaled tube radii (A).
+
+        -scale (float): Multiplier on the auto-scaled tube radii (default: 1.0).
+
+    Command-line usage:
+        $ mdpath_confidence_spline -paths top_pathways.pkl -coords residue_coordinates.pkl -conf edge_confidence.csv
+    """
+    from mdpath.src.path_confidence_viz import ConfidencePathVisualizer
+
+    parser = argparse.ArgumentParser(
+        prog="mdpath_confidence_spline",
+        description="Self-contained ChimeraX viewer of paths colored by confidence.",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("-paths", dest="paths", help="top_pathways.pkl", required=True)
+    parser.add_argument("-coords", dest="coords", help="residue_coordinates.pkl", required=True)
+    parser.add_argument("-conf", dest="conf", help="edge_confidence.csv", required=True)
+    parser.add_argument("-pdb", dest="pdb", help="Structure file to embed.", default="first_frame.pdb")
+    parser.add_argument("-top", dest="top", help="Number of top paths to render.", default=25)
+    parser.add_argument("-o", dest="out", help="Output ChimeraX .py.", default="confidence_paths_chimerax.py")
+    parser.add_argument("-radiusmin", dest="radiusmin", help="Override min tube radius (A).", default=None)
+    parser.add_argument("-radiusmax", dest="radiusmax", help="Override max tube radius (A).", default=None)
+    parser.add_argument("-scale", dest="scale", help="Multiplier on auto-scaled radii.", default=1.0)
+    args = parser.parse_args()
+
+    with open(args.paths, "rb") as f:
+        top_pathways = pickle.load(f)
+    with open(args.coords, "rb") as f:
+        residue_coordinates = pickle.load(f)
+    edge_confidence_df = pd.read_csv(args.conf)
+
+    summary = ConfidencePathVisualizer.write_chimerax_script(
+        top_pathways,
+        residue_coordinates,
+        edge_confidence_df,
+        pdb_file=args.pdb,
+        out_path=args.out,
+        top_n=int(args.top),
+        radius_min=None if args.radiusmin is None else float(args.radiusmin),
+        radius_max=None if args.radiusmax is None else float(args.radiusmax),
+        scale=float(args.scale),
+    )
+    print(
+        "\033[1mSaved {0} ({1} paths, tube radius {2:.2f}-{3:.2f} A). "
+        "Drag it onto a ChimeraX window.\033[0m".format(
+            summary["out_path"], summary["paths"],
+            summary["radius_min"], summary["radius_max"]
+        )
+    )
+    exit(0)
+
+
 def domain_mi_analysis():
     """
     Analyze mutual information within and between protein domains.

--- a/mdpath/src/path_confidence_viz.py
+++ b/mdpath/src/path_confidence_viz.py
@@ -1,0 +1,414 @@
+"""Confidence Path Visualization --- :mod:`mdpath.src.path_confidence_viz`
+===============================================================================
+
+This module contains the class :class:`ConfidencePathVisualizer` which turns the
+per-edge multi-replica confidence produced by
+:class:`mdpath.src.confidence.EdgeConfidenceCalculator` into a single,
+self-contained ChimeraX viewer for the top-ranked pathways.
+
+The pathways are drawn as spline tubes where
+
+* **colour** encodes confidence (blue = high, red = low) via a robust diverging
+  normalization computed once over all rendered paths,
+* **thickness** encodes how many of the rendered paths share each connection
+  (the same usage-based scaling as MDPath's original spline export), with the
+  absolute radius range **auto-scaled to the size of the structure** so it looks
+  right on any system, and
+* every point is a pickable ChimeraX *marker* carrying its confidence, so
+  hovering shows the value (``CONF nn`` = nn %, exact value in the B-factor).
+
+The output is a standalone ``.py`` ChimeraX script with the structure and the
+geometry embedded as base64 -- the user just drags it onto a ChimeraX window.
+
+Classes
+--------
+
+:class:`ConfidencePathVisualizer`
+"""
+
+import os
+import json
+import base64
+import textwrap
+
+import numpy as np
+import pandas as pd
+from scipy.interpolate import make_interp_spline, PchipInterpolator
+import matplotlib.pyplot as plt
+from matplotlib.colors import TwoSlopeNorm, Normalize, to_hex
+
+
+class ConfidencePathVisualizer:
+    """Build a self-contained ChimeraX viewer for confidence-coloured paths.
+
+    All methods are static; the entry point is :meth:`write_chimerax_script`.
+
+    Attributes:
+        NAN_RGB (tuple): RGB (0-1) used for connections with undefined confidence.
+
+        AUTOSCALE_FACTOR (float): Fraction of the structure bounding-box diagonal
+            used as the maximum tube radius when radii are auto-scaled.
+
+        AUTOSCALE_RATIO (float): Minimum/maximum tube-radius ratio.
+    """
+
+    NAN_RGB = (0.6, 0.6, 0.6)
+    AUTOSCALE_FACTOR = 0.0145
+    AUTOSCALE_RATIO = 0.25
+    RADIUS_ABS_BOUNDS = (0.12, 4.0)  # absolute clamp (A) so tiny/huge systems stay sane
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def conf_lookup_from_df(edge_confidence_df: pd.DataFrame) -> dict:
+        """Map canonical ``(min, max)`` residue pairs to their confidence value."""
+        lut = {}
+        for _, row in edge_confidence_df.iterrows():
+            a, b = int(row["Residue1"]), int(row["Residue2"])
+            lut[(min(a, b), max(a, b))] = float(row["confidence"])
+        return lut
+
+    @staticmethod
+    def edge_and_node_confidence(path, conf_lookup):
+        """Return ``(residues, edge_conf, node_conf)`` for a single path.
+
+        Edge confidence is looked up per consecutive residue pair; node (control
+        point) confidence lifts edges to points by averaging the two adjacent
+        edges (endpoints take their single neighbour). NaN-tolerant.
+        """
+        res = [int(x) for x in path]
+        edge = np.array(
+            [conf_lookup.get((min(a, b), max(a, b)), np.nan)
+             for a, b in zip(res[:-1], res[1:])],
+            float,
+        )
+        node = np.empty(len(res))
+        node[0], node[-1] = edge[0], edge[-1]
+        for k in range(1, len(res) - 1):
+            seg = edge[k - 1:k + 1]
+            node[k] = np.nanmean(seg) if np.isfinite(seg).any() else np.nan
+        return res, edge, node
+
+    @classmethod
+    def auto_radius_range(cls, residue_coordinates: dict, scale: float = 1.0):
+        """Derive a pleasant ``(radius_min, radius_max)`` from the structure size.
+
+        The maximum radius is a small fraction of the bounding-box diagonal of all
+        CA coordinates (so tubes are proportional to the scene on any system),
+        clamped to sane absolute bounds. ``scale`` multiplies the result.
+        """
+        coords = []
+        for c in residue_coordinates.values():
+            try:
+                coords.append(np.asarray(c[0], float))
+            except (TypeError, IndexError):
+                continue
+        lo_abs, hi_abs = cls.RADIUS_ABS_BOUNDS
+        if len(coords) < 2:
+            rmax = 1.0 * scale
+        else:
+            arr = np.array(coords)
+            diag = float(np.linalg.norm(arr.max(0) - arr.min(0)))
+            rmax = diag * cls.AUTOSCALE_FACTOR * scale
+        rmax = float(np.clip(rmax, max(lo_abs, 0.4), hi_abs))
+        rmin = float(np.clip(rmax * cls.AUTOSCALE_RATIO, lo_abs, rmax))
+        return rmin, rmax
+
+    @staticmethod
+    def build_norm(values, vmin=None, vcenter=None, vmax=None):
+        """Robust diverging normalization (2nd/98th percentile, median centre)."""
+        v = np.asarray([x for x in values if np.isfinite(x)], float)
+        if v.size == 0:
+            return Normalize(0.0, 1.0)
+        lo = np.quantile(v, 0.02) if vmin is None else vmin
+        hi = np.quantile(v, 0.98) if vmax is None else vmax
+        ctr = np.median(v) if vcenter is None else vcenter
+        if not lo < hi:
+            lo, hi = float(v.min()), float(v.max())
+        if not lo < hi:
+            return Normalize(lo - 1e-6, hi + 1e-6)
+        ctr = min(max(ctr, lo + 1e-9), hi - 1e-9)
+        return TwoSlopeNorm(vmin=lo, vcenter=ctr, vmax=hi)
+
+    @classmethod
+    def _rgb(cls, c, norm, cmap):
+        if not np.isfinite(c):
+            return cls.NAN_RGB
+        lo, hi = norm.vmin, norm.vmax
+        return tuple(cmap(norm(np.clip(c, lo, hi)))[:3])
+
+    @staticmethod
+    def _spline(coords, node_conf, node_radius, n_samples, rmin, rmax):
+        """Co-parameterized spline: cubic geometry, shape-preserving conf/radius."""
+        coords = np.asarray(coords, float)
+        K = len(coords)
+        t = np.linspace(0, 1, K)
+        tf = np.linspace(0, 1, n_samples)
+        kk = min(3, K - 1)
+        pts = np.column_stack(
+            [make_interp_spline(t, coords[:, d], k=kk)(tf) for d in range(3)]
+        )
+        fin = np.isfinite(node_conf)
+        if fin.sum() >= 2:
+            cf = np.clip(PchipInterpolator(t[fin], np.asarray(node_conf)[fin])(tf), 0.0, 1.0)
+        else:
+            cf = np.full(n_samples, np.nan)
+        rf = np.clip(PchipInterpolator(t, node_radius)(tf), rmin, rmax)
+        return pts, cf, rf
+
+    # ----------------------------------------------------------------- main API
+    @classmethod
+    def write_chimerax_script(
+        cls,
+        top_pathways,
+        residue_coordinates: dict,
+        edge_confidence_df: pd.DataFrame,
+        pdb_file: str = "first_frame.pdb",
+        out_path: str = "confidence_paths_chimerax.py",
+        top_n: int = 25,
+        n_samples: int = 70,
+        cmap_name: str = "RdBu",
+        radius_min=None,
+        radius_max=None,
+        scale: float = 1.0,
+        embed_structure: bool = True,
+    ) -> dict:
+        """Write a single self-contained ChimeraX ``.py`` viewer.
+
+        Args:
+            top_pathways (list[list[int]]): Rank-sorted paths (residue IDs).
+            residue_coordinates (dict): ``{res_id: [CA xyz, ...]}`` (MDPath output).
+            edge_confidence_df (pd.DataFrame): Per-edge confidence
+                (:meth:`EdgeConfidenceCalculator.build_edge_confidence_df`).
+            pdb_file (str): Structure the paths were computed on (embedded).
+            out_path (str): Output ``.py`` path.
+            top_n (int): Number of top paths to render.
+            n_samples (int): Spline samples per path.
+            cmap_name (str): Matplotlib diverging colormap (default blue=high/red=low).
+            radius_min, radius_max (float | None): Tube radius range in A. If either
+                is ``None`` the range is auto-scaled to the structure size.
+            scale (float): Multiplier applied to the auto-scaled radii.
+            embed_structure (bool): Embed ``pdb_file`` so the output is portable.
+
+        Returns:
+            dict: Summary ``{paths, sample_points, radius_min, radius_max, vmin,
+            vcenter, vmax, out_path}``.
+        """
+        cmap = plt.colormaps[cmap_name] if hasattr(plt, "colormaps") else plt.get_cmap(cmap_name)
+        lut = cls.conf_lookup_from_df(edge_confidence_df)
+
+        # --- per-path control points + confidence ---
+        paths = []
+        all_node_conf = []
+        for idx, raw in enumerate(top_pathways[:top_n]):
+            res, edge, node = cls.edge_and_node_confidence(raw, lut)
+            try:
+                coords = np.array([np.asarray(residue_coordinates[r][0], float) for r in res])
+            except KeyError:
+                continue
+            if len(coords) < 2:
+                continue
+            paths.append(dict(res=res, coords=coords, node=node))
+            all_node_conf.extend(node[np.isfinite(node)].tolist())
+        if not paths:
+            raise ValueError("No renderable paths (no residue coordinates matched).")
+
+        # --- auto-scaled radius range (unless overridden) ---
+        if radius_min is None or radius_max is None:
+            rmin, rmax = cls.auto_radius_range(residue_coordinates, scale=scale)
+            if radius_min is not None:
+                rmin = float(radius_min)
+            if radius_max is not None:
+                rmax = float(radius_max)
+        else:
+            rmin, rmax = float(radius_min), float(radius_max)
+
+        # --- thickness = how many rendered paths share each edge ---
+        from collections import Counter
+        edge_count = Counter()
+        for p in paths:
+            for a, b in zip(p["res"][:-1], p["res"][1:]):
+                edge_count[(min(a, b), max(a, b))] += 1
+        max_count = max(edge_count.values()) if edge_count else 1
+
+        def radius_for_count(c):
+            if max_count <= 1:
+                return 0.5 * (rmin + rmax)
+            return rmin + (rmax - rmin) * (c - 1) / (max_count - 1)
+
+        for p in paths:
+            er = np.array(
+                [radius_for_count(edge_count[(min(a, b), max(a, b))])
+                 for a, b in zip(p["res"][:-1], p["res"][1:])],
+                float,
+            )
+            nr = np.empty(len(p["res"]))
+            nr[0], nr[-1] = er[0], er[-1]
+            for k in range(1, len(p["res"]) - 1):
+                nr[k] = 0.5 * (er[k - 1] + er[k])
+            p["node_radius"] = nr
+
+        # --- normalization + geometry payload ---
+        norm = cls.build_norm(all_node_conf)
+        vmin, vmax = float(norm.vmin), float(norm.vmax)
+        vcenter = float(getattr(norm, "vcenter", 0.5 * (vmin + vmax)))
+
+        data = []
+        n_pts = 0
+        for p in paths:
+            pts, cf, rf = cls._spline(p["coords"], p["node"], p["node_radius"], n_samples, rmin, rmax)
+            samples = []
+            for i in range(len(pts)):
+                rr, gg, bb = cls._rgb(cf[i], norm, cmap)
+                conf = float(cf[i]) if np.isfinite(cf[i]) else -1.0
+                samples.append([
+                    round(float(pts[i, 0]), 2), round(float(pts[i, 1]), 2), round(float(pts[i, 2]), 2),
+                    int(round(rr * 255)), int(round(gg * 255)), int(round(bb * 255)),
+                    round(conf, 3), round(float(rf[i]), 3),
+                ])
+            data.append(samples)
+            n_pts += len(samples)
+        data_json = json.dumps(data, separators=(",", ":"))
+
+        # --- structure + colour key ---
+        if embed_structure and os.path.exists(pdb_file):
+            with open(pdb_file, "rb") as fh:
+                pdb_b64 = _wrap_b64(fh.read())
+            pdb_block = '_PDB_B64 = """\n%s\n"""' % pdb_b64
+            open_structure = (
+                "pdb_path = os.path.join(tempfile.gettempdir(), 'mdpath_conf_structure.pdb')\n"
+                "with open(pdb_path, 'wb') as fh:\n"
+                "    fh.write(_decode(_PDB_B64))\n"
+                'run(session, \'open "%s"\' % pdb_path.replace(os.sep, "/"))'
+            )
+        else:
+            pdb_block = "_PDB_B64 = None"
+            open_structure = "# (structure not embedded)"
+
+        data_b64 = _wrap_b64(data_json.encode("utf-8"))
+        c_lo, c_mid, c_hi = to_hex(cmap(norm(vmin))), to_hex(cmap(norm(vcenter))), to_hex(cmap(norm(vmax)))
+        key_cmd = (
+            "key %s:%.2f %s:%.2f %s:%.2f pos 0.06,0.08 size 0.27,0.03 fontSize 14"
+            % (c_lo, vmin, c_mid, vcenter, c_hi, vmax)
+        )
+        label_cmd = (
+            '2dlabels create mdpcap text "MDPath confidence  (blue = high, red = low)" '
+            "xpos 0.06 ypos 0.13 size 14"
+        )
+
+        script = _CHIMERAX_TEMPLATE.format(
+            top_n=len(paths), vmin=vmin, vcenter=vcenter, vmax=vmax,
+            rmin=rmin, rmax=rmax, pdb_block=pdb_block, open_structure=open_structure,
+            data_b64=data_b64, key_cmd=repr(key_cmd), label_cmd=repr(label_cmd),
+        )
+        with open(out_path, "w") as f:
+            f.write(script)
+
+        return dict(paths=len(paths), sample_points=n_pts, radius_min=rmin,
+                    radius_max=rmax, vmin=vmin, vcenter=vcenter, vmax=vmax,
+                    out_path=out_path)
+
+
+def _wrap_b64(raw: bytes) -> str:
+    return "\n".join(textwrap.wrap(base64.b64encode(raw).decode("ascii"), 120))
+
+
+_CHIMERAX_TEMPLATE = '''\
+"""
+MDPath confidence-colored pathways  ---  ChimeraX viewer (self-contained)
+========================================================================
+Drag this file onto a ChimeraX window (or:  File > Open, or  open <thisfile>).
+
+Shows the protein together with the top {top_n} MDPath pathways as spline tubes:
+
+  COLOR  = multi-replica confidence      blue = HIGH, red = LOW, gray = undefined
+  WIDTH  = how many paths share a connection (auto-scaled to the structure size;
+           radius {rmin:.2f}-{rmax:.2f} A, thin thread .. thick "trunk")
+  HOVER  = mouse over any path to read its confidence in the pop-up balloon
+           (shown as  "CONF nn"  where nn = confidence in %, e.g. CONF 77 = 0.77;
+            the exact value is the atom B-factor, see Selection Inspector)
+
+Normalization (robust, diverging) baked into this file:
+      vmin (red)    = {vmin:.3f}
+      vcenter(white)= {vcenter:.3f}
+      vmax (blue)   = {vmax:.3f}
+
+The pathways are a ChimeraX *marker model*, so every point is pickable.
+Generated by MDPath ConfidencePathVisualizer.
+"""
+import os, base64, json, tempfile
+from chimerax.core.commands import run
+
+{pdb_block}
+_DATA_B64 = """
+{data_b64}
+"""
+
+def _decode(b64):
+    return base64.b64decode("".join(b64.split()))
+
+def _safe(cmd):
+    try:
+        run(session, cmd)
+    except Exception as exc:
+        print("MDPath: skipped '%s' (%s)" % (cmd, exc))
+
+# ---- structure: gray cartoon (done BEFORE markers exist, so they're untouched) ----
+{open_structure}
+_safe("hide atoms")
+_safe("show cartoon")
+_safe("color #b8b8b8 target c")
+
+# ---- confidence pathways as a pickable marker model ----
+from chimerax.markers import MarkerSet
+try:
+    from chimerax.markers import create_link
+except Exception:
+    from chimerax.markers.markers import create_link
+try:
+    from chimerax.atomic import Atom
+    Atom.register_attr(session, "mdpath_confidence", "MDPath", attr_type=float)
+except Exception:
+    pass
+
+data = json.loads(_decode(_DATA_B64).decode("utf-8"))
+mset = MarkerSet(session, "MDPath confidence paths")
+n_markers = 0
+for path in data:
+    prev, prev_rgba, prev_rad = None, None, None
+    for x, y, z, R, G, B, conf, rad in path:
+        rgba = (R, G, B, 255)
+        m = mset.create_marker((x, y, z), rgba, rad)
+        n_markers += 1
+        if conf >= 0.0:
+            try: m.bfactor = conf
+            except Exception: pass
+            try: m.mdpath_confidence = conf
+            except Exception: pass
+            try:
+                m.residue.name = "CONF"
+                m.residue.number = int(round(conf * 100))
+            except Exception:
+                pass
+        if prev is not None:
+            try:
+                create_link(prev, m, prev_rgba, min(rad, prev_rad))
+            except Exception:
+                pass
+        prev, prev_rgba, prev_rad = m, rgba, rad
+try:
+    if mset.id is None:
+        session.models.add([mset])
+except Exception as exc:
+    print("MDPath: models.add note (%s)" % exc)
+
+# ---- scene + legend ----
+_safe("set bgColor white")
+_safe("lighting soft")
+_safe("graphics silhouettes true")
+run(session, "view")
+_safe({key_cmd})
+_safe({label_cmd})
+
+print("MDPath: {top_n} confidence-colored pathways as %d markers. "
+      "Hover a path to read its confidence (CONF nn = nn%%)." % n_markers)
+'''

--- a/mdpath/tests/test_path_confidence_viz.py
+++ b/mdpath/tests/test_path_confidence_viz.py
@@ -1,0 +1,360 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import sys
+import types
+
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.colors import TwoSlopeNorm, Normalize
+
+from mdpath.src.path_confidence_viz import ConfidencePathVisualizer as CPV
+
+
+# --------------------------------------------------------------------------- #
+# synthetic, self-contained inputs                                            #
+# --------------------------------------------------------------------------- #
+def _residue_coordinates():
+    """Six CA points spread in 3D (float32, like MDPath's real output)."""
+    return {
+        1: [np.array([0.0, 0.0, 0.0], dtype=np.float32)],
+        2: [np.array([10.0, 0.0, 0.0], dtype=np.float32)],
+        3: [np.array([20.0, 5.0, 0.0], dtype=np.float32)],
+        4: [np.array([30.0, 5.0, 5.0], dtype=np.float32)],
+        5: [np.array([40.0, 10.0, 5.0], dtype=np.float32)],
+        6: [np.array([50.0, 10.0, 10.0], dtype=np.float32)],
+    }
+
+
+def _top_pathways():
+    # edges used: (1,2)x2, (2,3)x3, (3,4)x1, (3,5)x1, (3,6)x1  -> max usage = 3
+    return [[1, 2, 3, 4], [1, 2, 3, 5], [2, 3, 6]]
+
+
+def _edge_confidence_df():
+    # some rows reversed (Residue1 > Residue2) to exercise canonicalization
+    return pd.DataFrame(
+        {
+            "Residue1": [2, 2, 4, 3, 6],
+            "Residue2": [1, 3, 3, 5, 3],
+            "confidence": [0.95, 0.90, 0.60, 0.75, 0.55],
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# mock ChimeraX so the generated script can be executed as ChimeraX would     #
+# --------------------------------------------------------------------------- #
+class _FakeResidue:
+    def __init__(self):
+        self.name = None
+        self.number = None
+
+
+class _FakeMarker:
+    def __init__(self, xyz, rgba, radius):
+        self.coord, self.rgba, self.radius = xyz, rgba, radius
+        self.residue = _FakeResidue()
+
+
+class _FakeModels:
+    def __init__(self):
+        self.added = []
+
+    def add(self, models):
+        for m in models:
+            m.id = (1,)
+        self.added.extend(models)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.models = _FakeModels()
+
+
+@pytest.fixture
+def fake_chimerax(monkeypatch):
+    """Install fake chimerax.* modules; return a recorder dict."""
+    rec = {"cmds": [], "markers": [], "links": 0}
+
+    def run(session, cmd):
+        rec["cmds"].append(cmd)
+
+    class _MarkerSet:
+        def __init__(self, session, name):
+            self.name = name
+            self.id = None
+
+        def create_marker(self, xyz, rgba, radius):
+            m = _FakeMarker(xyz, rgba, radius)
+            rec["markers"].append(m)
+            return m
+
+    def create_link(a, b, rgba=None, radius=None):
+        rec["links"] += 1
+
+    class _Atom:
+        @staticmethod
+        def register_attr(*args, **kwargs):
+            pass
+
+    mods = {n: types.ModuleType(n) for n in (
+        "chimerax", "chimerax.core", "chimerax.core.commands",
+        "chimerax.markers", "chimerax.markers.markers", "chimerax.atomic",
+    )}
+    mods["chimerax.core.commands"].run = run
+    mods["chimerax.core"].commands = mods["chimerax.core.commands"]
+    mods["chimerax"].core = mods["chimerax.core"]
+    mods["chimerax.markers"].MarkerSet = _MarkerSet
+    mods["chimerax.markers"].create_link = create_link
+    mods["chimerax.markers.markers"].create_link = create_link
+    mods["chimerax.atomic"].Atom = _Atom
+    for name, mod in mods.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    return rec
+
+
+def _run_generated(path):
+    ns = {"session": _FakeSession()}
+    exec(compile(path.read_text(), str(path), "exec"), ns)
+    return ns
+
+
+# --------------------------------------------------------------------------- #
+# confidence lookup + edge -> node lifting                                     #
+# --------------------------------------------------------------------------- #
+def test_conf_lookup_canonicalizes_pairs():
+    lut = CPV.conf_lookup_from_df(_edge_confidence_df())
+    assert lut[(1, 2)] == 0.95          # stored as (2, 1)
+    assert lut[(3, 4)] == 0.60          # stored as (4, 3)
+    assert lut[(3, 6)] == 0.55          # stored as (6, 3)
+    assert (2, 3) in lut and (3, 5) in lut
+
+
+def test_edge_and_node_confidence_lifting():
+    lut = CPV.conf_lookup_from_df(_edge_confidence_df())
+    res, edge, node = CPV.edge_and_node_confidence([1, 2, 3, 4], lut)
+    assert res == [1, 2, 3, 4]
+    np.testing.assert_allclose(edge, [0.95, 0.90, 0.60])
+    # endpoints take their single edge; interior nodes average the two
+    np.testing.assert_allclose(node, [0.95, (0.95 + 0.90) / 2, (0.90 + 0.60) / 2, 0.60])
+
+
+def test_edge_and_node_confidence_handles_missing_edges():
+    lut = CPV.conf_lookup_from_df(_edge_confidence_df())
+    # (1,4) and (4,1) are not present -> NaN edge; node lifting is NaN-tolerant
+    res, edge, node = CPV.edge_and_node_confidence([1, 4, 5], lut)
+    assert np.isnan(edge[0])             # (1,4) missing
+    assert edge[1] == 0.75 or np.isnan(edge[1])  # (4,5) missing -> NaN
+    # node[1] averages the finite neighbours only (here both missing -> NaN)
+    assert np.isnan(node[0])
+
+
+# --------------------------------------------------------------------------- #
+# auto colour ranging (the user's question)                                    #
+# --------------------------------------------------------------------------- #
+def test_colors_auto_range_from_input():
+    """The colour scale is derived from the input confidence distribution."""
+    low = [0.20, 0.30, 0.40, 0.50, 0.60]
+    high = [0.80, 0.85, 0.90, 0.95, 0.97]
+    norm_low = CPV.build_norm(low)
+    norm_high = CPV.build_norm(high)
+
+    assert isinstance(norm_low, TwoSlopeNorm)
+    # centre is the median of each input
+    assert norm_low.vcenter == pytest.approx(np.median(low))
+    assert norm_high.vcenter == pytest.approx(np.median(high))
+    # bounds are the 2nd / 98th percentiles of each input
+    assert norm_low.vmin == pytest.approx(np.quantile(low, 0.02))
+    assert norm_low.vmax == pytest.approx(np.quantile(low, 0.98))
+    # the two scales adapt: ranges are different and disjoint, not hardcoded
+    assert norm_low.vmax < norm_high.vmin
+
+
+def test_build_norm_respects_explicit_overrides():
+    norm = CPV.build_norm([0.1, 0.2, 0.9], vmin=0.0, vcenter=0.5, vmax=1.0)
+    assert (norm.vmin, norm.vcenter, norm.vmax) == (0.0, 0.5, 1.0)
+
+
+def test_build_norm_degenerate_inputs():
+    assert isinstance(CPV.build_norm([]), Normalize)        # empty -> plain 0..1
+    norm_const = CPV.build_norm([0.5, 0.5, 0.5])            # all equal -> no crash
+    assert norm_const.vmin < norm_const.vmax
+
+
+# --------------------------------------------------------------------------- #
+# colour mapping direction + NaN                                               #
+# --------------------------------------------------------------------------- #
+def test_rgb_blue_high_red_low_and_nan():
+    cmap = matplotlib.colormaps["RdBu"]
+    norm = CPV.build_norm([0.0, 0.5, 1.0], vmin=0.0, vcenter=0.5, vmax=1.0)
+    hi = CPV._rgb(0.95, norm, cmap)
+    lo = CPV._rgb(0.05, norm, cmap)
+    assert hi[2] > hi[0]                # high confidence -> blue dominates
+    assert lo[0] > lo[2]               # low confidence  -> red dominates
+    assert CPV._rgb(float("nan"), norm, cmap) == CPV.NAN_RGB
+
+
+# --------------------------------------------------------------------------- #
+# auto radius scaling                                                          #
+# --------------------------------------------------------------------------- #
+def test_auto_radius_scales_with_structure_size():
+    coords = _residue_coordinates()
+    arr = np.array([c[0] for c in coords.values()], float)
+    diag = np.linalg.norm(arr.max(0) - arr.min(0))
+    rmin, rmax = CPV.auto_radius_range(coords)
+    assert rmax == pytest.approx(diag * CPV.AUTOSCALE_FACTOR)
+    assert rmin == pytest.approx(rmax * CPV.AUTOSCALE_RATIO)
+    assert 0 < rmin < rmax
+    # scale multiplier roughly doubles the radius (within abs clamp)
+    _, rmax2 = CPV.auto_radius_range(coords, scale=2.0)
+    assert rmax2 == pytest.approx(min(rmax * 2.0, CPV.RADIUS_ABS_BOUNDS[1]))
+
+
+def test_auto_radius_clamps_tiny_and_huge():
+    tiny = {1: [np.zeros(3)], 2: [np.array([1.0, 0.0, 0.0])]}
+    _, rmax_tiny = CPV.auto_radius_range(tiny)
+    assert rmax_tiny == pytest.approx(0.4)                  # lower clamp
+    huge = {1: [np.zeros(3)], 2: [np.array([5000.0, 0.0, 0.0])]}
+    _, rmax_huge = CPV.auto_radius_range(huge)
+    assert rmax_huge == pytest.approx(CPV.RADIUS_ABS_BOUNDS[1])  # upper clamp
+
+
+# --------------------------------------------------------------------------- #
+# spline: shape, in-range, no overshoot                                        #
+# --------------------------------------------------------------------------- #
+def test_spline_in_range_and_shape_preserving():
+    coords = np.array([[0, 0, 0], [1, 0, 0], [2, 1, 0], [3, 1, 1]], float)
+    node_conf = np.array([0.6, 0.9, 0.7, 0.95])
+    node_radius = np.array([0.3, 1.0, 0.5, 0.3])
+    pts, cf, rf = CPV._spline(coords, node_conf, node_radius, 50, 0.3, 1.0)
+    assert pts.shape == (50, 3) and cf.shape == (50,) and rf.shape == (50,)
+    # spline passes through the endpoints
+    np.testing.assert_allclose(pts[0], coords[0], atol=1e-6)
+    np.testing.assert_allclose(pts[-1], coords[-1], atol=1e-6)
+    # PCHIP does not overshoot beyond the node value range (stable colours)
+    assert cf.min() >= node_conf.min() - 1e-9
+    assert cf.max() <= node_conf.max() + 1e-9
+    # radius stays within the requested bounds
+    assert rf.min() >= 0.3 - 1e-9 and rf.max() <= 1.0 + 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# write_chimerax_script: summary, valid output, auto behaviour                 #
+# --------------------------------------------------------------------------- #
+def test_write_chimerax_script_summary_and_valid_python(tmp_path):
+    out = tmp_path / "viewer.py"
+    summary = CPV.write_chimerax_script(
+        _top_pathways(), _residue_coordinates(), _edge_confidence_df(),
+        pdb_file="does_not_exist.pdb", out_path=str(out),
+        top_n=3, embed_structure=False,
+    )
+    assert out.exists()
+    assert summary["paths"] == 3
+    assert summary["sample_points"] == 3 * 70
+    assert summary["radius_min"] < summary["radius_max"]
+    assert summary["vmin"] <= summary["vcenter"] <= summary["vmax"]
+    compile(out.read_text(), str(out), "exec")    # generated file is valid Python
+
+
+def test_write_chimerax_script_color_range_follows_input(tmp_path):
+    """Two inputs with different confidence ranges -> different colour scales."""
+    coords, paths = _residue_coordinates(), [[1, 2, 3, 4]]
+    df_lo = pd.DataFrame({"Residue1": [1, 2, 3], "Residue2": [2, 3, 4],
+                          "confidence": [0.30, 0.40, 0.50]})
+    df_hi = pd.DataFrame({"Residue1": [1, 2, 3], "Residue2": [2, 3, 4],
+                          "confidence": [0.85, 0.90, 0.95]})
+    s_lo = CPV.write_chimerax_script(paths, coords, df_lo,
+                                     out_path=str(tmp_path / "lo.py"),
+                                     top_n=1, embed_structure=False)
+    s_hi = CPV.write_chimerax_script(paths, coords, df_hi,
+                                     out_path=str(tmp_path / "hi.py"),
+                                     top_n=1, embed_structure=False)
+    assert s_hi["vmin"] > s_lo["vmax"]            # scale tracked the input range
+
+
+def test_write_chimerax_script_radius_override(tmp_path):
+    s = CPV.write_chimerax_script(
+        _top_pathways(), _residue_coordinates(), _edge_confidence_df(),
+        out_path=str(tmp_path / "v.py"), top_n=3, embed_structure=False,
+        radius_min=0.5, radius_max=2.0,
+    )
+    assert (s["radius_min"], s["radius_max"]) == (0.5, 2.0)
+
+
+def test_write_chimerax_script_raises_without_coordinates(tmp_path):
+    df = _edge_confidence_df()
+    with pytest.raises(ValueError):
+        CPV.write_chimerax_script([[100, 101]], _residue_coordinates(), df,
+                                  out_path=str(tmp_path / "v.py"),
+                                  embed_structure=False)
+
+
+# --------------------------------------------------------------------------- #
+# generated script actually builds the marker model (mock ChimeraX)            #
+# --------------------------------------------------------------------------- #
+def test_generated_script_builds_marker_model(tmp_path, fake_chimerax):
+    out = tmp_path / "viewer.py"
+    CPV.write_chimerax_script(
+        _top_pathways(), _residue_coordinates(), _edge_confidence_df(),
+        out_path=str(out), top_n=3, embed_structure=False,
+    )
+    _run_generated(out)
+    markers = fake_chimerax["markers"]
+    assert len(markers) == 3 * 70                       # samples per path
+    assert fake_chimerax["links"] == 3 * 69            # links between samples
+    # hover encoding: residue name + percent number
+    assert {m.residue.name for m in markers} == {"CONF"}
+    assert all(0 <= m.residue.number <= 100 for m in markers)
+    # exact value stored as B-factor; colours are valid RGBA bytes
+    assert all(0.0 <= m.bfactor <= 1.0 for m in markers)
+    assert all(len(m.rgba) == 4 and all(0 <= c <= 255 for c in m.rgba) for m in markers)
+    # scene contains a colour-key legend and a framing 'view'
+    assert any(c.startswith("key ") for c in fake_chimerax["cmds"])
+    assert "view" in fake_chimerax["cmds"]
+
+
+def test_generated_script_marks_undefined_confidence_gray(tmp_path, fake_chimerax):
+    coords = {1: [np.array([0.0, 0.0, 0.0])], 2: [np.array([12.0, 0.0, 0.0])]}
+    df = pd.DataFrame({"Residue1": [7], "Residue2": [8], "confidence": [0.9]})  # no (1,2)
+    out = tmp_path / "viewer.py"
+    CPV.write_chimerax_script([[1, 2]], coords, df, out_path=str(out),
+                              top_n=1, embed_structure=False)
+    _run_generated(out)
+    gray = tuple(int(round(0.6 * 255)) for _ in range(3)) + (255,)
+    markers = fake_chimerax["markers"]
+    assert markers and all(tuple(m.rgba) == gray for m in markers)
+    assert all(m.residue.number is None for m in markers)   # not encoded when undefined
+
+
+# --------------------------------------------------------------------------- #
+# the standalone CLI                                                           #
+# --------------------------------------------------------------------------- #
+def test_confidence_spline_cli(tmp_path, monkeypatch):
+    import pickle
+
+    paths_pkl = tmp_path / "top_pathways.pkl"
+    coords_pkl = tmp_path / "residue_coordinates.pkl"
+    conf_csv = tmp_path / "edge_confidence.csv"
+    with open(paths_pkl, "wb") as f:
+        pickle.dump(_top_pathways(), f)
+    with open(coords_pkl, "wb") as f:
+        pickle.dump(_residue_coordinates(), f)
+    _edge_confidence_df().to_csv(conf_csv, index=False)
+    out = tmp_path / "cli_viewer.py"
+
+    monkeypatch.setattr(sys, "argv", [
+        "mdpath_confidence_spline",
+        "-paths", str(paths_pkl), "-coords", str(coords_pkl),
+        "-conf", str(conf_csv), "-o", str(out),
+        "-top", "3", "-pdb", "no_such_structure.pdb",
+    ])
+    from mdpath.mdpath_tools import confidence_spline
+
+    with pytest.raises(SystemExit) as exc:
+        confidence_spline()
+    assert exc.value.code == 0
+    assert out.exists()
+    compile(out.read_text(), str(out), "exec")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,5 @@ mdpath_multitraj = "mdpath.mdpath_tools:multitraj_analysis"
 mdpath_gpcr_image = "mdpath.mdpath_tools:gpcr_2D_vis"
 mdpath_spline = "mdpath.mdpath_tools:spline"
 mdpath_domain_mi = "mdpath.mdpath_tools:domain_mi_analysis"
+mdpath_confidence_spline = "mdpath.mdpath_tools:confidence_spline"
 


### PR DESCRIPTION
## Summary

  Adds a visualization that renders the top MDPath pathways in ChimeraX colored by
  multi-replica **confidence**, so users can see *where* an allosteric path is
  well-supported across replicas and where it isn't. It builds on the existing
  `EdgeConfidenceCalculator` (multi-replica `confidence = 1/(1+MI_cv)`) and produces
  a single, self-contained ChimeraX script you just drag onto a ChimeraX window.

  ## What it does

  The top paths are drawn as spline tubes encoding three things at once:

  - **Color = confidence** — diverging `RdBu` (blue = high, red = low, gray = undefined).
    The color *range* is auto-derived from the input distribution (robust
    `TwoSlopeNorm`: 2nd percentile / median / 98th percentile), so the gradient
    always spans the actual data. Overridable via explicit `vmin/vcenter/vmax`.
  - **Thickness = path usage** — how many of the rendered paths share each
    connection (the same usage-based scaling as the original spline export), with
    the absolute radius range **auto-scaled to the structure size** (fraction of the
    CA bounding-box diagonal, clamped). Overridable via `radius_min/radius_max/scale`.
  - **Hover = the value** — paths are a pickable ChimeraX `MarkerSet`; hovering shows
    `CONF nn` (nn = confidence %), with the exact value stored as the B-factor and a
    registered `mdpath_confidence` attribute.

  The output embeds the structure and geometry as base64, so it's a portable single
  file (no external dependencies at view time), and includes a color-key legend.

  ## How to use

  **Automatic** — added to the main pipeline's confidence route (requires ≥2 replicas):

      mdpath -top top.pdb -traj r1.dcd r2.dcd ... -confidence True
      # → also writes confidence_paths_chimerax.py

  **Standalone** — regenerate from existing analysis outputs:

      mdpath_confidence_spline -paths top_pathways.pkl \
          -coords residue_coordinates.pkl -conf edge_confidence.csv

  Then drag the generated `.py` onto a ChimeraX window.

  ## Changes

  New:
  - `mdpath/src/path_confidence_viz.py` — `ConfidencePathVisualizer` (compute → spline → color → ChimeraX export).
  - `mdpath/tests/test_path_confidence_viz.py` — 17 tests.

  Modified:
  - `mdpath/mdpath.py` — auto-generate the viewer in the `-confidence` route; updated help text.
  - `mdpath/mdpath_tools.py` — new `confidence_spline()` CLI.
  - `pyproject.toml` — new `mdpath_confidence_spline` entry point.

  ## Testing

  - New suite: 17 tests passing — covers confidence lifting, **auto color-ranging**,
    auto radius scaling, shape-preserving (no-overshoot) spline interpolation,
    hover encoding, NaN→gray handling, the generated script (executed under a mock
    ChimeraX), and the CLI.
  - Full suite collects cleanly (65 tests); existing `test_mdpath_tools.py` still passes.

  ## Notes

  - Backward compatible: purely additive; existing outputs/commands unchanged. The
    new ChimeraX file is only produced when `-confidence` is used.
  - The new `mdpath_confidence_spline` console command requires `pip install -e .`
    to register; the in-pipeline output works immediately with an editable install.